### PR TITLE
DEV: Handle blank slate category with no topics

### DIFF
--- a/sync_docs
+++ b/sync_docs
@@ -7,7 +7,6 @@ require "faraday/retry"
 require "faraday/multipart"
 require "listen"
 
-PRODUCTION_HOST = "https://meta.discourse.org"
 CATEGORY_ID = ENV["DOCS_CATEGORY_ID"].to_i
 DATA_EXPLORER_QUERY_ID = ENV["DOCS_DATA_EXPLORER_QUERY_ID"].to_i
 DOCS_TARGET = ENV["DOCS_TARGET"]
@@ -77,7 +76,7 @@ map_to_remote.call
 
 puts "Deleting topics if necessary..."
 
-cat_desc_topic_id = remote_topics.find { |t| t[:is_index_topic] }[:topic_id]
+cat_desc_topic_id = remote_topics.find { |t| t[:is_index_topic] }&.dig(:topic_id)
 remote_topics
   .reject { |remote_doc| remote_doc[:deleted_at] }
   .reject { |remote_doc| docs.any? { |doc| doc.topic_id == remote_doc[:topic_id] } }


### PR DESCRIPTION
This PR fixes the bug where the script errors out if no such starter topic is in the category to be synced with docs. 