### PR TITLE
DEV: handle missing index topic for docs category

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When working on substantial changes, you may like to set up a staging environmen
 1. Prepare a Discourse instance (could be a local development environment, or a production site)
 
    1. Create a category for the docs
-   2. Install [discourse-doc-categories](https://github.com/discourse/discourse-doc-categories), and enable it for the category
+   2. Install [discourse-doc-categories](https://github.com/discourse/discourse-doc-categories), and configure fully by adding the category & assigning an index topic
    3. Enable [DiscoTOC](https://meta.discourse.org/t/111143) for the category
    4. Ensure data-explorer is installed and enabled
 

--- a/sync_docs
+++ b/sync_docs
@@ -7,7 +7,6 @@ require "faraday/retry"
 require "faraday/multipart"
 require "listen"
 
-PRODUCTION_HOST = "https://meta.discourse.org"
 CATEGORY_ID = ENV["DOCS_CATEGORY_ID"].to_i
 DATA_EXPLORER_QUERY_ID = ENV["DOCS_DATA_EXPLORER_QUERY_ID"].to_i
 DOCS_TARGET = ENV["DOCS_TARGET"]
@@ -77,7 +76,13 @@ map_to_remote.call
 
 puts "Deleting topics if necessary..."
 
-cat_desc_topic_id = remote_topics.find { |t| t[:is_index_topic] }[:topic_id]
+cat_desc_topic = remote_topics.find { |t| t[:is_index_topic] }
+if cat_desc_topic.nil?
+  puts "Docs category is missing an index topic"
+  exit 1
+end
+cat_desc_topic_id = cat_desc_topic[:topic_id]
+
 remote_topics
   .reject { |remote_doc| remote_doc[:deleted_at] }
   .reject { |remote_doc| docs.any? { |doc| doc.topic_id == remote_doc[:topic_id] } }


### PR DESCRIPTION
This PR adds a clearer description before crashing in the error scenario where the category used for docs is missing an index topic. I've also updated the README for clarity.

Also removes an unused constant PRODUCTION_HOST.