### PR TITLE
Add themeable site settings docs

### DIFF
--- a/docs/05-themes-components/02-quick-reference.md
+++ b/docs/05-themes-components/02-quick-reference.md
@@ -16,6 +16,7 @@ As themes grow more powerful, there's more to remember about how they work. We h
 [:notebook_with_decorative_cover: Theme Directory](/c/theme)
 [:jigsaw: Component Directory](/c/theme-component)
 [:wrench: Theme Modifiers](https://meta.discourse.org/t/theme-modifiers-a-brief-introduction/150605)
+[:wrench: Themeable site settings](PLACEHOLDER_THEMEABLE)
 
 ### File/Folder Structure <small>[read more](https://meta.discourse.org/t/structure-of-themes-and-theme-components/60848)</small>
 
@@ -115,6 +116,30 @@ html {
   font-size: #{$global-font-size}px;
   background: $site-background;
 }
+```
+
+### Themeable site settings <small>[read more](PLACEHOLDER_THEMEABLE)</small>
+
+`about.json`:
+
+```json
+"theme_site_settings": {
+  "enable_welcome_banner": false
+}
+```
+
+Access from JavaScript:
+
+```js
+@service siteSettings;
+
+this.siteSettings.enable_welcome_banner;
+```
+
+Access from gjs templates:
+
+```gjs
+<template>{{this.siteSettings.enable_welcome_banner}}</template>
 ```
 
 ### Translations <small>[read more](https://meta.discourse.org/t/adding-localizable-strings-to-themes-and-theme-components/109867)</small>

--- a/docs/05-themes-components/09-theme-settings.md
+++ b/docs/05-themes-components/09-theme-settings.md
@@ -6,6 +6,8 @@ id: theme-settings
 
 Discourse has the ability for themes to have "settings" that can be added by theme developers to allow site owners to customize themes through UI without having to change any line of code and worry about losing their changes with future updates for the theme.
 
+Themes can also alter certain themeable site settings, for more information on that, see the [Themeable site settings](PLACEHOLDER_THEMEABLE) topic.
+
 ## :heavy_plus_sign: Adding settings to your theme
 
 Adding settings to your theme is a bit different from adding CSS and JS code, that is there is no way to do it via the UI.

--- a/docs/05-themes-components/35-themeable-site-settings.md
+++ b/docs/05-themes-components/35-themeable-site-settings.md
@@ -1,0 +1,47 @@
+---
+title: Controlling site settings with themes
+short_title: Themeable site settings
+id: themeable-site-settings
+---
+
+Themeable site settings allow a theme (not components) to override a small subset of core site settings, which generally control parts of the UI and other minor functionality. This allows themes to have a greater control over the full site experience.
+
+## :heavy_plus_sign: Adding themeable site settings
+
+All themeable site settings are defined in the core `config/site_settings.yml` file. Any setting with `themeable: true` will be available to themes.
+
+To override the default site setting value when the theme is installed, you can add this section in your theme's `about.json` file:
+
+```json
+{
+  "theme_site_settings": {
+    "enable_welcome_banner": true
+  }
+}
+```
+
+Any future updates to this value in your theme _will not change the saved database value_. This is to prevent themes from overriding site settings that the site admin has already changed.
+
+## :symbols: Supported types
+
+The types for themeable site settings are identical to the core site setting types. You do not need to define the type in `about.json`; just make sure the value is a valid one based on the site setting type.
+
+## :wrench: Using themeable site settings
+
+The core `siteSettings` service in JS is used to access the values of themeable site settings. You can access them like this:
+
+```javascript
+@service siteSettings;
+
+this.siteSettings.enable_welcome_banner;
+```
+
+This will also work in .gjs templates. Generally, you will not need to access these values in your theme, since the point of changing these in the theme is to change the behaviour of the core UI itself.
+
+## :capital_abcd: Setting description and localizations
+
+The core site setting description is used when showing themeable site settings to site admins on the theme config page, and also on the `/admin/config/themeable-site-settings` overview page.
+
+## :link: Related Topics
+
+- https://meta.discourse.org/t/developer-s-guide-to-discourse-themes/93648


### PR DESCRIPTION
Adds dev docs for the new themeable site settings functionality.

A followup PR will replace `PLACEHOLDER_THEMEABLE` with the
Meta URLs