### PR TITLE
Change app/assets/javascripts/ to frontend/

### DIFF
--- a/docs/03-code-internals/12-pluginapi.md
+++ b/docs/03-code-internals/12-pluginapi.md
@@ -16,7 +16,7 @@ export default apiInitializer((api) => {
 });
 ```
 
-All the available APIs are listed in the [`plugin-api.gjs` source code](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/plugin-api.gjs) in Discourse core, along with a short description and examples.
+All the available APIs are listed in the [`plugin-api.gjs` source code](https://github.com/discourse/discourse/blob/main/frontend/discourse/app/lib/plugin-api.gjs) in Discourse core, along with a short description and examples.
 
 For a full tuturial, including examples of JS API usage, check out:
 


### PR DESCRIPTION
This PR changes the link the the `plugin-api.gjs` file from the `app/assets/javascripts/` directory to the `frontend/` directory.